### PR TITLE
Fix MSIM incoming call notification handling.

### DIFF
--- a/src/com/android/incallui/StatusBarNotifier.java
+++ b/src/com/android/incallui/StatusBarNotifier.java
@@ -276,14 +276,6 @@ public class StatusBarNotifier implements InCallPresenter.InCallStateListener {
             return;
         }
 
-        // set the content
-        String contentText = mContext.getString(contentResId);
-        if (TelephonyManager.getDefault().isMultiSimEnabled()) {
-            SubInfoRecord info = SubscriptionManager.getSubInfoForSubscriber(call.getSubId());
-            if (info != null) {
-                contentText += " (" + info.displayName + ")";
-            }
-        }
         /*
          * Nothing more to check...build and send it.
          */
@@ -300,20 +292,16 @@ public class StatusBarNotifier implements InCallPresenter.InCallStateListener {
         }
 
         // Set the content
-        builder.setContentText(contentText);
+        builder.setContentText(mContext.getString(contentResId));
         builder.setSmallIcon(iconResId);
         builder.setContentTitle(contentTitle);
         builder.setLargeIcon(largeIcon);
         builder.setColor(mContext.getResources().getColor(R.color.dialer_theme_color));
 
         if (TelephonyManager.getDefault().isMultiSimEnabled()) {
-            final long subId = call.getSubId();
-            SubInfoRecord subInfoRecord = SubscriptionManager.getSubInfoForSubscriber(subId);
-            if (subInfoRecord != null) {
-                String displayName = subInfoRecord.displayName;
-                builder.setContentTitle(displayName);
-                builder.setContentText(contentTitle);
-                builder.setSubText(mContext.getString(contentResId));
+            SubInfoRecord info = SubscriptionManager.getSubInfoForSubscriber(call.getSubId());
+            if (info != null) {
+                builder.setSubText(info.displayName);
             }
         }
 


### PR DESCRIPTION
There's no need to handle MSIM twice for the notification. Additionally,
the SIM name isn't the most important information in that notification,
so don't treat it as such: Revert to AOSP behaviour (caller name as
title, 'incoming call' as content) and add the SIM name as subtext,
which matches what we already do for incoming SMS.

Change-Id: I4cb8bbb8fa4f44515e8552d6882fb7134978ad37